### PR TITLE
Configure kodiak for auto merging

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,84 @@
+# This file may be out-of-date and thus may not contain all of the possible configuration settings. See the [Kodiak documentation](https://github.com/chdsbd/kodiak/blob/master/README.md) and the [config schema](https://github.com/chdsbd/kodiak/blob/master/kodiak/test/fixtures/config/config-schema.json) for more info.
+# .kodiak.toml
+# version is the only required setting in a kodiak config.
+# it must be set to 1
+version = 1
+
+[merge]
+# label to use to enable Kodiak to merge a PR
+automerge_label = ":white_check_mark: needs merge" # default: "automerge"
+
+# require that the automerge label be set for Kodiak to merge a PR. if you
+# disable this Kodiak will immediately attempt to merge every PR you create
+require_automerge_label = true
+
+# if this title regex matches, Kodiak will not merge the PR. this is useful
+# to prevent merging work in progress PRs
+blacklist_title_regex = "^WIP.*" # default: "^WIP:.*", options: "" (disables regex), a regex string (e.g. ".*DONT\s*MERGE.*")
+
+# if these labels are set Kodiak will not merge the PR
+blacklist_labels = [":heart: needs acceptance", ":construction: work in progress", ":face_with_head_bandage: needs revision", ":link:  depends on another PR", ":raising_hand_man: needs assistance", ":stop_sign: do not merge"] # default: [], options: list of label names (e.g. ["wip"])
+
+# choose a merge method. If the configured merge method is disabled for a
+# repository, Kodiak will report an error in a status message.
+method = "squash" # default: "merge", options: "merge", "squash", "rebase"
+
+# once a PR is merged into master, delete the branch
+delete_branch_on_merge = true # default: false
+
+# if you request review from a user, don't merge until that user provides a
+# review, even if the PR is passing all checks
+block_on_reviews_requested = false # default: false
+
+# if there is a merge conflict, make a comment on the PR and remove the
+# automerge label. this is disabled when require_automerge_label is enabled
+notify_on_conflict = true # default: true
+
+# if there are running status checks on a PR when it's up for merge, don't
+# wait for those to finish before updating the branch
+optimistic_updates = true # default: true
+
+# use this for status checks that run indefinitely, like deploy jobs or the
+# WIP GitHub App
+dont_wait_on_status_checks = [] # default: [], options: list of check names (e.g. ["ci/circleci: lint_api"])
+
+# immediately update a PR whenever the target updates. If enabled, Kodiak will
+# not be able to efficiently update PRs. Any time the target of a PR updates,
+# the PR will update.
+#
+# If you have multiple PRs against a target like "master", any time a commit
+# is added to "master" _all_ of those PRs against "master" will update.
+#
+# For N PRs against a target you will potentially see N(N-1)/2 updates. If
+# this configuration option was disabled you would only see N-1 updates.
+#
+# If you have continuous integration (CI) run on every commit, enabling this
+# configuration option will likely increase your CI costs if you pay per
+# minute. If you pay per build host, this will likely increase job queueing.
+update_branch_immediately = false # default: false
+
+# if a PR is passing all checks and is able to be merged, merge it without
+# placing it in the queue. This will introduce some unfairness where those
+# waiting in the queue the longest will not be served first.
+prioritize_ready_to_merge = false # default: false
+
+
+[merge.message]
+# by default, github uses the first commit title for the PR of a merge.
+# "pull_request_title" uses the PR title.
+title = "pull_request_title" # default: "github_default", options: "github_default", "pull_request_title"
+
+# by default, GithHub combines the titles a PR's commits to create the body
+# text of a merge. "pull_request_body" uses the content of the PR to generate
+# the body content while "empty" simple gives an empty string.
+body = "pull_request_body" # default: "github_default", options: "github_default", "pull_request_body", "empty"
+
+# GitHub adds the PR number to the title of merges created through the UI.
+# This setting replicates that feature.
+include_pr_number = true # default: true
+
+# markdown is the normal format for GitHub merges
+body_type = "markdown" # default: "markdown", options: "plain_text", "markdown", "html"
+
+# useful for stripping HTML comments created by PR templates when the `markdown` `body_type` is used.
+strip_html_comments = false # default: false


### PR DESCRIPTION
### Purpose
- [x] Configure kodiak to auto merge PRs

### Usage
- add `needs-merge` tag to a PR to auto run all workflows, rules, merge and delete feature branch.
- Git squash and merge is used as a merge strategy
- PR title is set as commit message
- PR body is set as commit description