### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=120

--- a/.github/hooks/autopep8.sh
+++ b/.github/hooks/autopep8.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+declare -a ERRORS=()
+echo "\nRunning autopep8 🚓 💨 💨 💨"
+
+for file in $(git diff --cached --name-only | grep -E '.py')
+do
+	ERRORS+=("$(autopep8 --in-place --aggressive --aggressive $file)")
+done
+
+if [[ "$ERRORS" != "" ]]; then
+	echo "🚨 BEE-BOP! There are some linting errors that need to be fixed and recommitted!"
+	history -p "${ERRORS[@]}"
+  exit 0
+fi
+
+echo "Done! autopep8 has no complaints! ✅\n"
+
+exit 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: check-yaml
+    - id: check-json
+    - id: check-toml
+    - id: check-xml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+    - id: fix-byte-order-marker
+    - id: mixed-line-ending
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: autopep8
+        name: autopep8
+        description: Run autopep8 against changed ruby files
+        entry: .github/hooks/autopep8.sh
+        language: system
+        verbose: true
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+
   - repo: local
     hooks:
       - id: autopep8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: autopep8
         name: autopep8
-        description: Run autopep8 against changed ruby files
+        description: Run autopep8 against changed .py files
         entry: .github/hooks/autopep8.sh
         language: system
         verbose: true

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 Django Rest APIs
 
 ### Using Precommit hooks
-- Install pre-commit `brew install pre-commit`
-- Run `pre-commit --version` just to check if installed correctly
-- Run `pre-commit install` to install pre-commit on your system
+1. Install pre-commit `brew install pre-commit`
+2. Run `pre-commit --version` just to check if installed correctly
+3. Run `pre-commit install` to install pre-commit on your system
+4. Run `chmod +x .github/hooks/autopep8.sh` from current wkdir to let your system be able to run .sh file
+5. You'll also need to have autopep8 installed on your system so run `pip3 install autopep8`
 - In case you want to skip pre-commit on a commit do `git commit -nm` instead of `git commit -m`
 - Check guide to [pre-commit](https://pre-commit.com/) if need further help!
+
+###### P.S: I'll switch to [mirrors-commit](https://github.com/pre-commit/mirrors-autopep8) instead of custom hook for autopep8 so that it's no longer a system level dependency and you'll ever not need to configure anything locally, that's the heart of docker!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # django-rest-api
 Django Rest APIs
+
+### Using Precommit hooks
+- Install pre-commit `brew install pre-commit`
+- Run `pre-commit --version` just to check if installed correctly
+- Run `pre-commit install` to install pre-commit on your system
+- In case you want to skip pre-commit on a commit do `git commit -nm` instead of `git commit -m`
+- Check guide to [pre-commit](https://pre-commit.com/) if need further help!

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,3 @@
 flake8>=3.9.2,<=3.10
 autopep8
+pre-commit


### PR DESCRIPTION
### Purpose 
This PR adds pre-commit hooks for the following purposes
- [x] Run [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks)
- [x] Run [flake8](https://github.com/pycqa/flake8) to check for any code offenses
- [x] Local run autopep8.sh to auto correct any code offenses in .py files

### Usage
- install pre-commit `brew install pre-commit`
- run `pre-commit --version` just to check if installed correctly
- run `pre-commit install`
- In case you want to skip pre-commit on a commit do `git commit -nm` instead of `git commit -m`
- Check guide to [pre-commit](https://pre-commit.com/) for further help!